### PR TITLE
Fix spelling of committer in LineInfo typing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,10 +28,10 @@ interface LineInfo {
   authorMail: string;
   authorTime: number;
   authorTz: string;
-  commiter: string;
-  commiterMail: string;
-  commiterTime: number;
-  commiterTz: string;
+  committer: string;
+  committerMail: string;
+  committerTime: number;
+  committerTz: string;
   summary: string;
   previous: string;
   filename: string;


### PR DESCRIPTION
In the LineInfo structure, "committer" is mis-spelled with one "t".

https://github.com/tinovyatkin/git-blame-json/blob/8911767c4436ec0b247203fc1ff886eee5a7bb96/src/index.ts#L31-L34

but in the results from this library, "committer" is correctly spelled with two t's. You can even see that reflected in the unit test:

https://github.com/tinovyatkin/git-blame-json/blob/8911767c4436ec0b247203fc1ff886eee5a7bb96/src/index.test.ts#L18-L21

This updates the structure to match the actual output.